### PR TITLE
Follow option was removed from replace module in ansible 2.5

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -548,7 +548,6 @@
 - name: Do not allow users to reuse recent passwords - system-auth (change)
   replace:
     dest: /etc/pam.d/system-auth
-    follow: true
     regexp: ^(password\s+sufficient\s+pam_unix\.so\s.*remember\s*=\s*)(\S+)(.*)$
     replace: \g<1>{{ var_password_pam_unix_remember }}\g<3>
   tags:
@@ -576,7 +575,6 @@
 - name: Do not allow users to reuse recent passwords - system-auth (add)
   replace:
     dest: /etc/pam.d/system-auth
-    follow: true
     regexp: ^password\s+sufficient\s+pam_unix\.so\s(?!.*remember\s*=\s*).*$
     replace: \g<0> remember={{ var_password_pam_unix_remember }}
   tags:
@@ -1162,7 +1160,6 @@
 - name: Prevent Log In to Accounts With Empty Password - system-auth
   replace:
     dest: /etc/pam.d/system-auth
-    follow: true
     regexp: nullok
   tags:
   - CCE-27286-4
@@ -1191,7 +1188,6 @@
 - name: Prevent Log In to Accounts With Empty Password - password-auth
   replace:
     dest: /etc/pam.d/password-auth
-    follow: true
     regexp: nullok
   tags:
   - CCE-27286-4


### PR DESCRIPTION
This role is failing on new versions of ansible due to the `follow` option being removed from the replace module:

https://docs.ansible.com/ansible/latest/collections/ansible/builtin/replace_module.html#notes